### PR TITLE
Fix: abi type error + webview overrides

### DIFF
--- a/app/counter.tsx
+++ b/app/counter.tsx
@@ -38,7 +38,7 @@ const counterContract = {
       type: 'function',
     }
   ],
-};
+} as const;
 
 export default function Counter() {
   const { wallet } = useWallet();
@@ -57,13 +57,7 @@ export default function Counter() {
       setIsPending(true);
       const { hash, explorerLink } = await evmWallet.sendTransaction({
         to: counterContract.address,
-        contractAbi: [{
-          inputs: [],
-          name: 'increment',
-          outputs: [],
-          stateMutability: 'nonpayable',
-          type: 'function',
-        }],
+        abi: counterContract.abi,
         functionName: 'increment',
         args: [],
       });

--- a/package.json
+++ b/package.json
@@ -65,5 +65,10 @@
 		"react-test-renderer": "19.0.0",
 		"typescript": "^5.8.2"
 	},
+	"pnpm": {
+		"overrides": {
+		  "react-native-webview": "13.13.5"
+		}
+	  },
 	"private": true
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  react-native-webview: 13.13.5
+
 importers:
 
   .:
@@ -11,6 +14,9 @@ importers:
       '@crossmint/client-sdk-react-native-ui':
         specifier: ^0.10.1
         version: 0.10.1(uptovpdgcqcneicrhhr4mi6ryq)
+      '@crossmint/wallets-sdk':
+        specifier: ^0.11.6
+        version: 0.11.6(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@expo/vector-icons':
         specifier: ^14.1.0
         version: 14.1.0(expo-font@13.3.2(expo@53.0.20(@babel/core@7.28.0)(@expo/metro-runtime@5.0.4(react-native@0.79.3(@babel/core@7.28.0)(@types/react@19.0.14)(bufferutil@4.0.9)(react@19.0.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(react-native-webview@13.13.5(react-native@0.79.3(@babel/core@7.28.0)(@types/react@19.0.14)(bufferutil@4.0.9)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))(react-native@0.79.3(@babel/core@7.28.0)(@types/react@19.0.14)(bufferutil@4.0.9)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))(react-native@0.79.3(@babel/core@7.28.0)(@types/react@19.0.14)(bufferutil@4.0.9)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)
@@ -121,8 +127,8 @@ importers:
         specifier: ~19.0.10
         version: 19.0.14
       '@types/react-test-renderer':
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.0.0
+        version: 19.1.0
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -145,8 +151,8 @@ importers:
         specifier: ^3.5.3
         version: 3.6.2
       react-test-renderer:
-        specifier: 18.3.1
-        version: 18.3.1(react@19.0.0)
+        specifier: 19.0.0
+        version: 19.0.0(react@19.0.0)
       typescript:
         specifier: ^5.8.2
         version: 5.9.2
@@ -688,13 +694,13 @@ packages:
       '@expo/config-plugins': '>=9.0.0'
       react: '>=17.0.2'
       react-native: '>=0.74.3'
-      react-native-webview: '>=13.13.5 <13.15.0'
+      react-native-webview: 13.13.5
 
   '@crossmint/client-sdk-rn-window@0.3.4':
     resolution: {integrity: sha512-Ktne1BpgPyLW6YQooSN8c/6atOcjH0XG/qEwKWBg251p7/OXAKmF/e4RhXM3aEQwuRNf5RjkrmmG5cXMsIbT4Q==}
     peerDependencies:
       react: '>=18.0.0'
-      react-native-webview: '>=13.0.0'
+      react-native-webview: 13.13.5
 
   '@crossmint/client-sdk-window@1.0.3':
     resolution: {integrity: sha512-Qr6KFYFoh3Cu2W6clsPNncYXHc6WOmF30f7cZu/aLAhlUKdNNS/yT5hHe6ieWv2HWgJoLAA5dAoHC7vbM82u8A==}
@@ -1323,14 +1329,8 @@ packages:
   '@types/node@24.2.1':
     resolution: {integrity: sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==}
 
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
-
-  '@types/react-test-renderer@18.3.1':
-    resolution: {integrity: sha512-vAhnk0tG2eGa37lkU9+s5SoroCsRI08xnsWFiAXOuPH2jqzMbcXvKExXViPi1P5fIklDeCvXqyrdmipFaSkZrA==}
-
-  '@types/react@18.3.23':
-    resolution: {integrity: sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==}
+  '@types/react-test-renderer@19.1.0':
+    resolution: {integrity: sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==}
 
   '@types/react@19.0.14':
     resolution: {integrity: sha512-ixLZ7zG7j1fM0DijL9hDArwhwcCb4vqmePgwtV0GfnkHRSCUEv4LvzarcTdhoqgyMznUx/EhoTUv31CKZzkQlw==}
@@ -2749,7 +2749,7 @@ packages:
       '@expo/metro-runtime': '*'
       react: '*'
       react-native: '*'
-      react-native-webview: '*'
+      react-native-webview: 13.13.5
     peerDependenciesMeta:
       '@expo/dom-webview':
         optional: true
@@ -4366,6 +4366,11 @@ packages:
     resolution: {integrity: sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==}
     peerDependencies:
       react: ^18.3.1
+
+  react-test-renderer@19.0.0:
+    resolution: {integrity: sha512-oX5u9rOQlHzqrE/64CNr0HB0uWxkCQmZNSfozlYvwE71TLVgeZxVf0IjouGEr1v7r1kcDifdAJBeOhdhxsG/DA==}
+    peerDependencies:
+      react: ^19.0.0
 
   react@19.0.0:
     resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
@@ -7239,16 +7244,9 @@ snapshots:
     dependencies:
       undici-types: 7.10.0
 
-  '@types/prop-types@15.7.15': {}
-
-  '@types/react-test-renderer@18.3.1':
+  '@types/react-test-renderer@19.1.0':
     dependencies:
-      '@types/react': 18.3.23
-
-  '@types/react@18.3.23':
-    dependencies:
-      '@types/prop-types': 15.7.15
-      csstype: 3.1.3
+      '@types/react': 19.0.14
 
   '@types/react@19.0.14':
     dependencies:
@@ -10911,6 +10909,12 @@ snapshots:
       react-is: 18.3.1
       react-shallow-renderer: 16.15.0(react@19.0.0)
       scheduler: 0.23.2
+
+  react-test-renderer@19.0.0(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-is: 19.1.1
+      scheduler: 0.25.0
 
   react@19.0.0: {}
 


### PR DESCRIPTION
- Added as const to counterContract definition to ensure proper TypeScript literal types for Crossmint SDK compatibility
- Fixed sendTransaction parameter from contractAbi to abi and use full counterContract.abi reference
- Added pnpm overrides for react-native-webview@13.13.5 to resolve dependency conflicts
- Updated pnpm-lock.yaml to reflect new override configuration

https://github.com/user-attachments/assets/7d41f501-895e-4aa8-b4ab-a2623e0a3a66

